### PR TITLE
fix: ignore ssh2 and cpu-features build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,9 @@ onlyBuiltDependencies:
 
 # Dev-only transitive packages with install scripts we intentionally skip (prebuilt or optional native).
 ignoredBuiltDependencies:
+  - cpu-features
   - eslint-plugin-n8n-nodes-base
+  - ssh2
   - unrs-resolver
 
 # Wait 24h before installing newly published versions.


### PR DESCRIPTION
Prevent pnpm install from failing under strictDepBuilds when n8n-workflow pulls in these optional native transitive packages.